### PR TITLE
[new iOS] no jailbreak for iOS 9.3

### DIFF
--- a/app/data/jailbreaks.json
+++ b/app/data/jailbreaks.json
@@ -7,7 +7,7 @@
             "url": "",
             "ios": {
                 "start": "9.2",
-                "end": "9.2.1"
+                "end": "9.3"
             },
             "caveats": "",
             "platforms": []


### PR DESCRIPTION
Added iOS 9.3 to the list.
