### PR TITLE
Pangu moved iOS 9.2-9.3.3 jailbreak link

### DIFF
--- a/jailbreaks.json
+++ b/jailbreaks.json
@@ -16,7 +16,7 @@
       "jailbroken": true,
       "name": "Pangu",
       "version": "1.1",
-      "url": "http://en.pangu.io/help.html",
+      "url": "http://en.93.pangu.io/help.html",
       "ios": {
         "start": "9.2",
         "end": "9.3.3"


### PR DESCRIPTION
Pangu might be releasing a new jailbreak soon, because they have moved the page for the iOS 9.2-9.3.3 jailbreak!