### PR TITLE
[New iOS] No jailbreak for iOS 11.0.2

### DIFF
--- a/jailbreaks.json
+++ b/jailbreaks.json
@@ -7,7 +7,7 @@
       "url": "",
       "ios": {
         "start": "10.2.1",
-        "end": "11.0.1"
+        "end": "11.0.2"
       },
       "caveats": "",
       "platforms": []


### PR DESCRIPTION
iOS 11.0.2 was just released, no jailbreak yet.