### PR TITLE
[New iOS] No jailbreak for 11.1.2

### DIFF
--- a/jailbreaks.json
+++ b/jailbreaks.json
@@ -7,7 +7,7 @@
       "url": "",
       "ios": {
         "start": "10.2.1",
-        "end": "11.1.1"
+        "end": "11.1.2"
       },
       "caveats": "",
       "platforms": []


### PR DESCRIPTION
iOS 11.1.2 dropped, no known jailbreak yet.