### PR TITLE
Remove Yalu

### DIFF
--- a/jailbreaks.json
+++ b/jailbreaks.json
@@ -83,21 +83,6 @@
     },
     {
       "jailbroken": true,
-      "name": "Yalu (beta, unstable)",
-      "url": "http://www.redmondpie.com/how-to-jailbreak-ios-10.2-with-yalu102-tutorial/",
-      "ios": {
-        "start": "10.0",
-        "end": "10.2"
-      },
-      "caveats": "Recommended for advanced users only. Semi-untethered. Does not work on iPhone 7. Follow RedmondPie tutorial",
-      "platforms": [
-        "Windows",
-        "macOS",
-        "Linux"
-      ]
-    },
-    {
-      "jailbroken": true,
       "name": "Extra_Recipe+YaluX (beta, unstable)",
       "url": "https://yalu.qwertyoruiop.com/",
       "ios": {


### PR DESCRIPTION
No use for this jailbreak anymore as doubleH3lix is better in every way. Also Anemone will soon not support Yalu, but they will support doubleH3lix, The yalu jailbreak is dead!