### PR TITLE
Update: unc0ver iOS 12 now supports pre-A12 devices

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -19,8 +19,8 @@ jailbreaks:
   - macOS
   - Linux
   caveats: > 
-    Currently A12 devices like iPhone XR, XS and XS Max are
-    not yet supported, please wait for an update.
+    Currently A12 devices like iPhone XR, XS and XS Max
+    are not yet supported, please wait for an update.
   
 - jailbroken: true
   name: unc0ver

--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -19,8 +19,8 @@ jailbreaks:
   - macOS
   - Linux
   caveats: > 
-    A8X to A11 devices only. Currently A12 devices like iPhone XR, XS and
-    XS Max are not yet supported, please wait for an update.
+    Currently A12 devices like iPhone XR, XS and XS Max are
+    not yet supported, please wait for an update.
   
 - jailbroken: true
   name: unc0ver


### PR DESCRIPTION
Removed "A8X to A11 devices only".