### PR TITLE
[New iOS] No jailbreak for 12.3.2

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -4,7 +4,7 @@ jailbreaks:
   url: ""
   firmwares:
     start: 12.1.3
-    end: 12.3.1
+    end: 12.3.2
   platforms: []
   caveats: ""
 


### PR DESCRIPTION
New iOS dropped for iPhone 8 Plus (just the single device) yesterday, no jailbreak yet.