### PR TITLE
Phœnix supports iOS 9.3.6

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -120,7 +120,7 @@ jailbreaks:
   url: https://phoenixpwn.com
   firmwares:
     start: 9.3.5
-    end: ""
+    end: 9.3.6
   platforms:
   - Windows
   - macOS


### PR DESCRIPTION
Apple has released iOS 9.3.6 on most 32-bit devices stuck on iOS 9.
Phœnix supports this new version.