### PR TITLE
[New iOS] No jailbreak for 12.4.1

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -1,4 +1,12 @@
 jailbreaks:
+- jailbroken: false
+  name: ""
+  url: ""
+  firmwares:
+    start: 12.4.1
+  platforms: []
+  caveats: ""
+
 - jailbroken: true
   name: unc0ver
   url: https://github.com/pwn20wndstuff/Undecimus/releases


### PR DESCRIPTION
iOS 12.4.1 dropped this afternoon, no jailbreak yet.