### PR TITLE
[New iOS] No jailbreak for 13.1

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -4,7 +4,7 @@ jailbreaks:
   url: ""
   firmwares:
     start: 12.4.1
-    end: 13.0
+    end: 13.1
   platforms: []
   caveats: ""
 


### PR DESCRIPTION
iOS 13.1 dropped this afternoon, no jailbreak yet.