### PR TITLE
[New iOS] No jailbreak for 13.1.2

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -4,7 +4,7 @@ jailbreaks:
   url: ""
   firmwares:
     start: 12.4.1
-    end: 13.1.1
+    end: 13.1.2
   platforms: []
   caveats: ""
 


### PR DESCRIPTION
Apple is on fire lately, dropping releases left and right. 13.1.2 dropped this afternoon, no jailbreak yet.