### PR TITLE
[New iOS] 13.3 released

### DIFF
--- a/jailbreaks.yml
+++ b/jailbreaks.yml
@@ -4,7 +4,7 @@ jailbreaks:
   url: https://checkra.in/
   firmwares:
     start: 12.3
-    end: 13.2.3
+    end: 13.3
   platforms:
   - macOS
   caveats: Currently in beta. Supports devices iPhone 5s to iPhone X. Semi-tethered. Windows version coming soon, some device support not fully tested yet.


### PR DESCRIPTION
iOS 13.2.3 is released, nothing so far indicates that it can't be jailbroken with checkra1n